### PR TITLE
add Loading page

### DIFF
--- a/lib/coffe_cup.dart
+++ b/lib/coffe_cup.dart
@@ -12,6 +12,7 @@ export 'features/assets/horn/assets_horns.dart';
 export 'features/widgets/coffee_rating.dart';
 export 'features/images/coffee_image.dart';
 export 'features/pages/unicorn_page.dart';
+export 'features/pages/loading_page.dart';
 export 'features/cards/image_card/ui/coffee_manga_cover.dart';
 export 'features/assets/states/assets_state.dart';
 export 'features/images/coffee_asset_image.dart';

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -1,8 +1,10 @@
 import 'package:coffee_cup/coffe_cup.dart';
 import 'package:flutter/material.dart';
+import 'package:manga_easy_themes/manga_easy_themes.dart';
 
 class LoadingPage extends StatefulWidget {
-  const LoadingPage({super.key});
+  final double animationValue;
+  const LoadingPage({super.key, required this.animationValue});
 
   @override
   State<LoadingPage> createState() => _LoadingPageState();
@@ -17,7 +19,16 @@ class _LoadingPageState extends State<LoadingPage> {
         Image(
           image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
         ),
-        const CoffeeText(text: 'Carregando...')
+        const CoffeeText(text: 'Carregando...'),
+        const SizedBox(
+          height: 10,
+        ),
+        LinearProgressIndicator(
+          value: widget.animationValue,
+          semanticsLabel: 'Linear progress indicator',
+          minHeight: 8,
+          color: ThemeService.of.primaryColor,
+        ),
       ],
     );
   }

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -1,0 +1,24 @@
+import 'package:coffee_cup/coffe_cup.dart';
+import 'package:flutter/material.dart';
+
+class LoadingPage extends StatefulWidget {
+  const LoadingPage({super.key});
+
+  @override
+  State<LoadingPage> createState() => _LoadingPageState();
+}
+
+class _LoadingPageState extends State<LoadingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Image(
+          image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
+        ),
+        const CoffeeText(text: 'Carregando...')
+      ],
+    );
+  }
+}

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -19,9 +19,12 @@ class _LoadingPageState extends State<LoadingPage> {
         Image(
           image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
         ),
-        const CoffeeText(text: 'Carregando...'),
+        const CoffeeText(
+          text: 'Carregando...',
+          typography: CoffeeTypography.button,
+        ),
         const SizedBox(
-          height: 10,
+          height: 20,
         ),
         LinearProgressIndicator(
           value: widget.animationValue,


### PR DESCRIPTION
Para usar, é preciso passar o atributo double value do widget LinearProgressIndicator
o atributo double animationValue, vai de 0.0 à 1.0

O ideal é reconstruir esse widget a cada frame passando um novo value, assim a barra de progressão aumenta.
![loading-gif](https://github.com/manga-easy/manga_easy_coffee_cup/assets/65208006/deddbfed-c804-459e-b726-e2e83db70428)

