### PR TITLE
added loading page and on press adjust

### DIFF
--- a/lib/coffe_cup.dart
+++ b/lib/coffe_cup.dart
@@ -12,6 +12,7 @@ export 'features/assets/horn/assets_horns.dart';
 export 'features/widgets/coffee_rating.dart';
 export 'features/images/coffee_image.dart';
 export 'features/pages/unicorn_page.dart';
+export 'features/pages/loading_page.dart';
 export 'features/cards/image_card/ui/coffee_manga_cover.dart';
 export 'features/assets/states/assets_state.dart';
 export 'features/images/coffee_asset_image.dart';

--- a/lib/features/buttons/coffee_button.dart
+++ b/lib/features/buttons/coffee_button.dart
@@ -4,7 +4,7 @@ import 'package:manga_easy_themes/manga_easy_themes.dart';
 
 class CoffeeButton extends StatelessWidget {
   final String label;
-  final void Function()? onPress;
+  final void Function()? onPressed;
   final Color? corButton;
   final Color? corTexto;
   final EdgeInsetsGeometry padding;
@@ -15,7 +15,7 @@ class CoffeeButton extends StatelessWidget {
   const CoffeeButton({
     super.key,
     required this.label,
-    this.onPress,
+    this.onPressed,
     this.corButton,
     this.corTexto,
     this.padding = const EdgeInsets.symmetric(vertical: 16),
@@ -33,7 +33,7 @@ class CoffeeButton extends StatelessWidget {
         children: [
           Expanded(
             child: TextButton.icon(
-              onPressed: onPress,
+              onPressed: onPressed,
               style: TextButton.styleFrom(
                 elevation: elevation,
                 backgroundColor: corButton ?? ThemeService.of.primaryColor,

--- a/lib/features/dialogs/coffee_dialog_uni.dart
+++ b/lib/features/dialogs/coffee_dialog_uni.dart
@@ -88,7 +88,7 @@ class CoffeeDialogUnicorn extends StatelessWidget {
               child: CoffeeButton(
                 label: 'OK',
                 padding: const EdgeInsets.symmetric(vertical: 10),
-                onPress: () {
+                onPressed: () {
                   Navigator.of(context).pop();
                 },
               ),

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -19,18 +19,19 @@ class _LoadingPageState extends State<LoadingPage> {
         Image(
           image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
         ),
-        const CoffeeText(
-          text: 'Carregando...',
-          typography: CoffeeTypography.button,
-        ),
-        const SizedBox(
-          height: 20,
-        ),
         LinearProgressIndicator(
           value: widget.animationValue,
           semanticsLabel: 'Linear progress indicator',
-          minHeight: 8,
+          minHeight: 12,
+          borderRadius: ThemeService.of.borderRadius,
           color: ThemeService.of.primaryColor,
+        ),
+        const SizedBox(
+          height: 10,
+        ),
+        CoffeeText(
+          text: '${(widget.animationValue * 100).ceil()}%',
+          typography: CoffeeTypography.button,
         ),
       ],
     );

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -1,8 +1,10 @@
 import 'package:coffee_cup/coffe_cup.dart';
 import 'package:flutter/material.dart';
+import 'package:manga_easy_themes/manga_easy_themes.dart';
 
 class LoadingPage extends StatefulWidget {
-  const LoadingPage({super.key});
+  final double animationValue;
+  const LoadingPage({super.key, required this.animationValue});
 
   @override
   State<LoadingPage> createState() => _LoadingPageState();
@@ -17,7 +19,16 @@ class _LoadingPageState extends State<LoadingPage> {
         Image(
           image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
         ),
-        const CoffeeText(text: 'Carregando...')
+        const CoffeeText(text: 'Carregando...'),
+        const SizedBox(
+          height: 10,
+        ),
+        LinearProgressIndicator(
+          value: widget.animationValue,
+          semanticsLabel: 'Linear progress indicator',
+          minHeight: 8,
+          color: ThemeService.of.primaryColor,
+        ),
       ],
     );
   }

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -19,12 +19,14 @@ class _LoadingPageState extends State<LoadingPage> {
         Image(
           image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
         ),
-        LinearProgressIndicator(
-          value: widget.animationValue,
-          semanticsLabel: 'Linear progress indicator',
-          minHeight: 12,
+        ClipRRect(
           borderRadius: ThemeService.of.borderRadius,
-          color: ThemeService.of.primaryColor,
+          child: LinearProgressIndicator(
+            value: widget.animationValue,
+            semanticsLabel: 'Linear progress indicator',
+            minHeight: 12,
+            color: ThemeService.of.primaryColor,
+          ),
         ),
         const SizedBox(
           height: 10,

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -16,8 +16,8 @@ class _LoadingPageState extends State<LoadingPage> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Image(
-          image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
+        CoffeeImage.cats(
+          AssetsCats.runningCircle,
         ),
         ClipRRect(
           borderRadius: ThemeService.of.borderRadius,

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -1,0 +1,24 @@
+import 'package:coffee_cup/coffe_cup.dart';
+import 'package:flutter/material.dart';
+
+class LoadingPage extends StatefulWidget {
+  const LoadingPage({super.key});
+
+  @override
+  State<LoadingPage> createState() => _LoadingPageState();
+}
+
+class _LoadingPageState extends State<LoadingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Image(
+          image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
+        ),
+        const CoffeeText(text: 'Carregando...')
+      ],
+    );
+  }
+}

--- a/lib/features/pages/loading_page.dart
+++ b/lib/features/pages/loading_page.dart
@@ -19,9 +19,12 @@ class _LoadingPageState extends State<LoadingPage> {
         Image(
           image: CoffeeAssetImage.cats(AssetsCats.runningCircle),
         ),
-        const CoffeeText(text: 'Carregando...'),
+        const CoffeeText(
+          text: 'Carregando...',
+          typography: CoffeeTypography.button,
+        ),
         const SizedBox(
-          height: 10,
+          height: 20,
         ),
         LinearProgressIndicator(
           value: widget.animationValue,

--- a/lib/features/pages/unicorn_page.dart
+++ b/lib/features/pages/unicorn_page.dart
@@ -67,7 +67,7 @@ class UnicornPage extends StatelessWidget {
                 padding: const EdgeInsets.all(8.0),
                 child: CoffeeButton(
                   label: titleButton ?? 'OK',
-                  onPress: actionButton ?? () => Navigator.pop(context),
+                  onPressed: actionButton ?? () => Navigator.pop(context),
                 ),
               ),
             ],


### PR DESCRIPTION
Para usar, é preciso passar o atributo double value do widget LinearProgressIndicator
o atributo double animationValue, vai de 0.0 à 1.0

O ideal é reconstruir esse widget a cada frame passando um novo value, assim a barra de progressão aumenta.
![loading-gif](https://github.com/manga-easy/manga_easy_coffee_cup/assets/65208006/2ac34e76-3a5b-4176-a291-568cccbb422f)
